### PR TITLE
Fix: Correct cargo tarpaulin and update release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       run: cargo install cargo-tarpaulin
 
     - name: Generate coverage report
-      run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+      run: cargo tarpaulin --verbose --features async --workspace --timeout 120 --out xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches: [main, master]
   workflow_dispatch:
 
 permissions:
@@ -13,6 +11,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check_changes.outputs.should_release }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Fixes `cargo tarpaulin` execution in CI:** The `coverage` job in `ci.yml` was failing because the `zbus` transitive dependency was not being compiled with required features (`async-io` or `tokio`). The `cargo tarpaulin` command has been updated to explicitly include `--features async`, which enables `tokio` and resolves the compilation error.

2.  **Updates release workflow for manual trigger and robustness:**
    - The `release.yml` workflow trigger has been changed from `on: [push, workflow_dispatch]` to `on: workflow_dispatch` to ensure releases are only triggered manually, as per your request.
    - The `release` job in `release.yml` now correctly exposes the `should_release` output from its `check_changes` step. This allows the dependent `build-cross-platform` job to reliably determine if it should run based on whether releasable changes were found.

These changes improve the CI stability and align the release process with the desired manual workflow.